### PR TITLE
Fix dry-runs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
                         {
                           type = "app";
                           program = toString (mkDeployScript {
-                            machine = x;
+                            machine = nixpkgs.lib.removeSuffix "-dry-run" x;
                             dryRun = true;
                           });
                         }


### PR DESCRIPTION
Co-authored-by: Mason Mackaman <masondeanm@aol.com>

The dry-run scripts were never tested for functionality, only evaluation, but the `machine` argument of `mkDeployScript` was never set correctly, which fixes the bug.