### PR TITLE
tests/vmTest: fix and deduplicate code

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
       nixpkgsFor = forAllSystems (system: pkgs: import nixpkgs { inherit system; overlays = [ self.overlay ]; });
     in rec
     {
+      herculesCI.ciSystems = [ "x86_64-linux" ];
       overlay = final: prev: {
         generateApps = flake:
           let

--- a/tests/vmTest/common.nix
+++ b/tests/vmTest/common.nix
@@ -1,0 +1,14 @@
+# Configuration that will be added to both the nixinatee node and the nixinator
+# node.
+{ inputs }:
+{
+  nix = {
+    extraOptions =
+      let empty_registry = builtins.toFile "empty-flake-registry.json" ''{"flakes":[],"version":2}''; in
+      ''
+        experimental-features = nix-command flakes
+        flake-registry = ${empty_registry}
+      '';
+    registry.nixpkgs.flake = inputs.nixpkgs;
+  };
+}

--- a/tests/vmTest/default.nix
+++ b/tests/vmTest/default.nix
@@ -22,86 +22,85 @@ let
     ((import (path + "/flake.nix")).outputs (inputs // {self = r;}));
   in
     r;
-  exampleFlake = pkgs.writeTextFile {
-    name = "nixinate-example-flake";
-    destination = "/flake.nix";
-    text = ''
-      {
-        outputs = { self, nixpkgs }:
-          let
-            makeTest = (import (nixpkgs + "/nixos/lib/testing-python.nix") { system = "${pkgs.hostPlatform.system}"; }).makeTest;
-            baseConfig = ((makeTest { nodes.baseConfig = { ... }: {}; testScript = "";}).nodes {}).baseConfig.extendModules {
-              modules = [
-                ${builtins.readFile ./nixinateeBase.nix}
-                ${builtins.readFile ./nixinateeAdditional.nix}
-                {
-                  _module.args.nixinate = {
-                    host = "nixinatee";
-                    sshUser = "nixinator";
-                    buildOn = "local"; # valid args are "local" or "remote"
-                  };
-                }
-              ];
-            };
-          in
+  mkNixinateTest = buildOn:
+    let
+      exampleFlake = pkgs.writeTextFile {
+        name = "nixinate-example-flake";
+        destination = "/flake.nix";
+        text = ''
           {
-            nixosConfigurations = {
-              nixinatee = baseConfig;
-            };
+            outputs = { self, nixpkgs }:
+              let
+                makeTest = (import (nixpkgs + "/nixos/lib/testing-python.nix") { system = "${pkgs.hostPlatform.system}"; }).makeTest;
+                baseConfig = ((makeTest { nodes.baseConfig = { ... }: {}; testScript = "";}).nodes {}).baseConfig.extendModules {
+                  modules = [
+                    ${builtins.readFile ./nixinateeBase.nix}
+                    ${builtins.readFile ./nixinateeAdditional.nix}
+                    {
+                      _module.args.nixinate = {
+                        host = "nixinatee";
+                        sshUser = "nixinator";
+                        buildOn = "${buildOn}"; # valid args are "local" or "remote"
+                      };
+                    }
+                  ];
+                };
+              in
+              {
+                nixosConfigurations = {
+                  nixinatee = baseConfig;
+                };
+              };
+          }
+        '';
+      };
+      deployScript = inputs.self.nixinate.${pkgs.hostPlatform.system} (callLocklessFlake "${exampleFlake}" { nixpkgs = inputs.nixpkgs; });
+      exampleSystem = (callLocklessFlake "${exampleFlake}" { nixpkgs = inputs.nixpkgs; }).nixosConfigurations.nixinatee.config.system.build.toplevel;
+    in
+    makeTest {
+      nodes = {
+        nixinatee = { ... }: {
+          imports = [
+            ./nixinateeBase.nix
+            (import ./common.nix { inherit inputs; })
+          ];
+          virtualisation = {
+            writableStore = true;
+            additionalPaths = [] ++ pkgs.lib.optional (buildOn == "remote") (allDrvOutputs exampleSystem);
           };
-      }
-    '';
-  };
-  deployScript = inputs.self.nixinate.${pkgs.hostPlatform.system} (callLocklessFlake "${exampleFlake}" { nixpkgs = inputs.nixpkgs; });
-  exampleSystem = (callLocklessFlake "${exampleFlake}" { nixpkgs = inputs.nixpkgs; }).nixosConfigurations.nixinatee.config.system.build.toplevel;
-  mkNixinateTest = buildOn: makeTest {
-    nodes = {
-      nixinatee = { ... }: {
-        imports = [
-          ./nixinateeBase.nix
-        ];
-        virtualisation = {
-          writableStore = true;
+        };
+        nixinator = { ... }: {
+          imports = [
+            (import ./common.nix { inherit inputs; })
+          ];
+          virtualisation = {
+            additionalPaths = [
+              (allDrvOutputs exampleSystem)
+            ]
+              ++ pkgs.lib.optional (buildOn == "remote") exampleFlake;
+          };
         };
       };
-      nixinator = { ... }: {
-        virtualisation = {
-          additionalPaths = [
-            (allDrvOutputs exampleSystem)
-          ]
-            ++ pkgs.lib.optional (buildOn == "remote") exampleFlake;
-        };
-        nix = {
-          extraOptions =
-            let empty_registry = builtins.toFile "empty-flake-registry.json" ''{"flakes":[],"version":2}''; in
-            ''
-              experimental-features = nix-command flakes
-              flake-registry = ${empty_registry}
-            '';
-          registry.nixpkgs.flake = inputs.nixpkgs;
-        };
-      };
+      testScript =
+        ''
+          start_all()
+          nixinatee.wait_for_unit("sshd.service")
+          nixinator.wait_for_unit("multi-user.target")
+          nixinator.succeed("mkdir ~/.ssh/")
+          nixinator.succeed("ssh-keyscan -H nixinatee >> ~/.ssh/known_hosts")
+          nixinator.succeed("exec ${deployScript.nixinate.nixinatee.program} >&2")
+          nixinatee.wait_for_unit("nginx.service")
+          nixinatee.wait_for_open_port("80")
+          with subtest("Check that Nginx webserver can be reached by deployer after deployment"):
+              assert "<title>Welcome to nginx!</title>" in nixinator.succeed(
+                  "curl -sSf http:/nixinatee/ | grep title"
+              )
+          with subtest("Check that Nginx webserver can be reached by deployee after deployment"):
+              assert "<title>Welcome to nginx!</title>" in nixinatee.succeed(
+                  "curl -sSf http:/127.0.0.1/ | grep title"
+              )
+        '';
     };
-    testScript =
-      ''
-        start_all()
-        nixinatee.wait_for_unit("sshd.service")
-        nixinator.wait_for_unit("multi-user.target")
-        nixinator.succeed("mkdir ~/.ssh/")
-        nixinator.succeed("ssh-keyscan -H nixinatee >> ~/.ssh/known_hosts")
-        nixinator.succeed("exec ${deployScript.nixinate.nixinatee.program} >&2")
-        nixinatee.wait_for_unit("nginx.service")
-        nixinatee.wait_for_open_port("80")
-        with subtest("Check that Nginx webserver can be reached by deployer after deployment"):
-            assert "<title>Welcome to nginx!</title>" in nixinator.succeed(
-                "curl -sSf http:/nixinatee/ | grep title"
-            )
-        with subtest("Check that Nginx webserver can be reached by deployee after deployment"):
-            assert "<title>Welcome to nginx!</title>" in nixinatee.succeed(
-                "curl -sSf http:/127.0.0.1/ | grep title"
-            )
-      '';
-  };
 in
 {
   local = (mkNixinateTest "local");


### PR DESCRIPTION
Ironically, I did not properly test that I had made the local and remote tests distinct. So the exampleFlake was hardcoded to 'local' only.  So, when building vmTests.local meaning you would get the same results as vmTests.remote, this commit fixes that. Additionally, I've made tests/vmTests/common.nix to deduplicate some of the code between nodes.