### PR TITLE
Fix hermetic remote builds and tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
               inherit (final.lib) getExe;
               nix = "${getExe final.nix}";
               nixos-rebuild = "${getExe final.nixos-rebuild}";
+              nixos-rebuild-drvPath = final.nixos-rebuild.drvPath;
               openssh = "${getExe final.openssh}";
 
               n = flake.nixosConfigurations.${machine}._module.args.nixinate;
@@ -50,8 +51,8 @@
                 ( set -x; ${nix} copy ${flake} --to ssh://${user}@${host} )
               '' + (if hermetic then ''
                 echo "🤞 Activating configuration hermetically on ${machine} via ssh:"
-                ( set -x; ${nix} build ${nixos-rebuild} --no-link --store ssh://${user}@${host} )
-                ( set -x; ${openssh} -t ${user}@${host} 'sudo ${nixos-rebuild} ${switch} --flake ${flake}#${machine}' )
+                ( set -x; ${nix} copy --derivation ${nixos-rebuild} --to ssh://${user}@${host} )
+                ( set -x; ${openssh} -t ${user}@${host} 'sudo nix-store --realise ${nixos-rebuild-drvPath} && sudo ${nixos-rebuild} ${switch} --flake ${flake}#${machine}' )
               '' else ''
                 echo "🤞 Activating configuration non-hermetically on ${machine} via ssh:"
                 ( set -x; ${openssh} -t ${user}@${host} 'sudo nixos-rebuild ${switch} --flake ${flake}#${machine}' )

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2,4 +2,6 @@
 {
   vmTestLocal = (import ./vmTest { inherit pkgs makeTest inputs; }).local;
   vmTestRemote = (import ./vmTest { inherit pkgs makeTest inputs; }).remote;
+  vmTestLocalHermetic = (import ./vmTest { inherit pkgs makeTest inputs; }).localHermetic;
+  vmTestRemoteHermetic = (import ./vmTest { inherit pkgs makeTest inputs; }).remoteHermetic;
 }


### PR DESCRIPTION
In the previous attempt to add this feature, I had forgotten to add the
new tests to tests/default.nix, which meant I believed the feature
worked when it did not. Additionally, real world testing shows that if
the path does not exist on the remote already, that nix build --store
will not work and will throw the following error: 'path '/nix/store/foo'
is required, but there is no substituter that can build it' To fix this,
I've decided to use nix copy --derivation and then nix-store --realise
on the remote. A lot of refactoring is needed to make this codebase
presentable anyway, so this hack is fine for now, though it is
admittedly an unclean implementation.

https://github.com/MatthewCroughan/nixinate/pull/20