### PR TITLE
Add locking via flock(1)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,10 +52,10 @@
               '' + (if hermetic then ''
                 echo "🤞 Activating configuration hermetically on ${machine} via ssh:"
                 ( set -x; ${nix} copy --derivation ${nixos-rebuild} --to ssh://${user}@${host} )
-                ( set -x; ${openssh} -t ${user}@${host} 'sudo nix-store --realise ${nixos-rebuild} && sudo ${nixos-rebuild} ${switch} --flake ${flake}#${machine}' )
+                ( set -x; ${openssh} -t ${user}@${host} "sudo nix-store --realise ${nixos-rebuild} && sudo ${nixos-rebuild} ${switch} --flake ${flake}#${machine}" )
               '' else ''
                 echo "🤞 Activating configuration non-hermetically on ${machine} via ssh:"
-                ( set -x; ${openssh} -t ${user}@${host} 'sudo nixos-rebuild ${switch} --flake ${flake}#${machine}' )
+                ( set -x; ${openssh} -t ${user}@${host} "sudo nixos-rebuild ${switch} --flake ${flake}#${machine}" )
               '')
               else ''
                 echo "🔨 Building system closure locally, copying it to remote store and activating it:"

--- a/flake.nix
+++ b/flake.nix
@@ -52,14 +52,14 @@
               '' + (if hermetic then ''
                 echo "🤞 Activating configuration hermetically on ${machine} via ssh:"
                 ( set -x; ${nix} copy --derivation ${nixos-rebuild} --to ssh://${user}@${host} )
-                ( set -x; ${openssh} -t ${user}@${host} "sudo nix-store --realise ${nixos-rebuild} && sudo ${nixos-rebuild} ${switch} --flake ${flake}#${machine}" )
+                ( set -x; ${openssh} -t ${user}@${host} "sudo flock -w 60 /dev/shm/nixinate-${machine} -c 'nix-store --realise ${nixos-rebuild} && sudo ${nixos-rebuild} ${switch} --flake ${flake}#${machine}'" )
               '' else ''
                 echo "🤞 Activating configuration non-hermetically on ${machine} via ssh:"
-                ( set -x; ${openssh} -t ${user}@${host} "sudo nixos-rebuild ${switch} --flake ${flake}#${machine}" )
+                ( set -x; ${openssh} -t ${user}@${host} "sudo flock -w 60 /dev/shm/nixinate-${machine} -c 'nixos-rebuild ${switch} --flake ${flake}#${machine}'" )
               '')
               else ''
                 echo "🔨 Building system closure locally, copying it to remote store and activating it:"
-                ( set -x; NIX_SSHOPTS="-t" ${nixos-rebuild} ${switch} --flake ${flake}#${machine} --target-host ${user}@${host} --use-remote-sudo ${optionalString substituteOnTarget "-s"} )
+                ( set -x; NIX_SSHOPTS="-t" flock -w 60 /dev/shm/nixinate-${machine} -c '${nixos-rebuild} ${switch} --flake ${flake}#${machine} --target-host ${user}@${host} --use-remote-sudo ${optionalString substituteOnTarget "-s"}' )
               '');
             in final.writeScript "deploy-${machine}.sh" script;
           in


### PR DESCRIPTION
If two Nixinate deployments were executed in parallel, it would cause two activation scripts to run in parallel which can cause failure.

It is not clear whether the correct solution is to use `flock` via Nixinate, or whether `nixos-rebuild` or even the activation script should be implementing the locking. Either way, this PR solves the problem from Nixinate's point of view by adding "advisory" file descriptor based locks on the filesystem via `/dev/shm`.

Also of note is the fact that I have to figure out a way to make `flock` work with the `hermetic = true` argument, before it can be merged. Otherwise, it would be a dependency which prevents support for other platforms. It is otherwise an impurity that is expected on the remote side.

##### Helpful references
- https://www.baeldung.com/linux/file-locking