### PR TITLE
Add support for SSH options

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ Connection to itchy.scratchy.com closed.
   built a lot of the paths from the previous deployment. However, if the remote
   has a slow upload bandwidth, this would not be a good idea to enable.
 
+- `nixOptions` *`listOf strings`*
+
+  Extra options passed to all invocations of `nix`.
+
+- `sshOptions` *`listOfStrings`*
+
+  Extra options passed to all invocations of `ssh`.
+
 # Project Principles
 
 * No Premature Optimization: Make it work, then optimize it later if the

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
               substituteOnTarget = n.substituteOnTarget or false;
               switch = if dryRun then "dry-activate" else "switch";
               nixOptions = concatStringsSep " " (n.nixOptions or []);
+              sshOptions = concatStringsSep " " (n.sshOptions or []);
 
               script =
               ''
@@ -55,10 +56,10 @@
               '' + (if hermetic then ''
                 echo "🤞 Activating configuration hermetically on ${machine} via ssh:"
                 ( set -x; ${nix} ${nixOptions} copy --derivation ${nixos-rebuild} ${flock} --to ssh://${user}@${host} )
-                ( set -x; ${openssh} -t ${user}@${host} "sudo nix-store --realise ${nixos-rebuild} ${flock} && sudo ${flock} -w 60 /dev/shm/nixinate-${machine} ${nixos-rebuild} ${nixOptions} ${switch} --flake ${flake}#${machine}" )
+                ( set -x; ${openssh} ${sshOptions} -t ${user}@${host} "sudo nix-store --realise ${nixos-rebuild} ${flock} && sudo ${flock} -w 60 /dev/shm/nixinate-${machine} ${nixos-rebuild} ${nixOptions} ${switch} --flake ${flake}#${machine}" )
               '' else ''
                 echo "🤞 Activating configuration non-hermetically on ${machine} via ssh:"
-                ( set -x; ${openssh} -t ${user}@${host} "sudo flock -w 60 /dev/shm/nixinate-${machine} nixos-rebuild ${switch} --flake ${flake}#${machine}" )
+                ( set -x; ${openssh} ${sshOptions} -t ${user}@${host} "sudo flock -w 60 /dev/shm/nixinate-${machine} nixos-rebuild ${switch} --flake ${flake}#${machine}" )
               '')
               else ''
                 echo "🔨 Building system closure locally, copying it to remote store and activating it:"


### PR DESCRIPTION
This enables users of nixinate to use options such as `ssh -A` (to forward the ssh agent for sudo) or `-J` to jump through a bastion host.

Also update documentation with the missing nixOptions.