### PR TITLE
apps: add description

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
                    (x:
                      {
                        type = "app";
+                       meta.description = "Deploy NixOS configuration '${x}' to remote host";
                        program = toString (mkDeployScript {
                          machine = x;
                          dryRun = false;
@@ -86,6 +87,7 @@
                       (x:
                         {
                           type = "app";
+                          meta.description = "Dry-run deployment of NixOS configuration '${nixpkgs.lib.removeSuffix "-dry-run" x}' (shows what would be activated without making changes)";
                           program = toString (mkDeployScript {
                             machine = nixpkgs.lib.removeSuffix "-dry-run" x;
                             dryRun = true;


### PR DESCRIPTION
you run `nix run --help`, you are presented with:

```
      | apps.x86_64-linux.blender_2_79 = {
      |   type = "app";
      |   program = "${self.packages.x86_64-linux.blender_2_79}/bin/blender";
      |   meta.description = "Run Blender, a free and open-source 3D creation suite.";
      | };
```

this is currently declared optional, but missing and already shows warnings for `nix flake check`.