### PR TITLE
Use `nixVersions.latest` instead of the now-deprecated `nixVersions.unstable`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1653060744,
-        "narHash": "sha256-kfRusllRumpt33J1hPV+CeCCylCXEU7e0gn2/cIM7cY=",
+        "lastModified": 1762977756,
+        "narHash": "sha256-4PqRErxfe+2toFJFgcRKZ0UI9NSIOJa+7RXVtBhy4KE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dfd82985c273aac6eced03625f454b334daae2e8",
+        "rev": "c5ae371f1a6a7fd27823bc500d9390b38c05fa55",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       overlay = final: prev: {
         nixinate = {
           nix = prev.pkgs.writeShellScriptBin "nix"
-            ''${final.nixVersions.unstable}/bin/nix --experimental-features "nix-command flakes" "$@"'';
+            ''${final.nixVersions.latest}/bin/nix --experimental-features "nix-command flakes" "$@"'';
           nixos-rebuild = prev.nixos-rebuild.override { inherit (final) nix; };
         };
         generateApps = flake:


### PR DESCRIPTION
This change is necessary for local building if one wants to use nixinate with a newer `nixpkgs` input.